### PR TITLE
Replace `Enum.chunk/2` with `Enum.chunk_every/2`

### DIFF
--- a/lib/easy_ssl.ex
+++ b/lib/easy_ssl.ex
@@ -172,7 +172,7 @@ defmodule EasySSL do
     :crypto.hash(:sha, certificate)
     |> Base.encode16
     |> String.to_charlist
-    |> Enum.chunk(2)
+    |> Enum.chunk_every(2, 2, :discard)
     |> Enum.join(":")
   end
 
@@ -299,7 +299,7 @@ defmodule EasySSL do
                 subject_key_identifier
                 |> Base.encode16
                 |> String.to_charlist
-                |> Enum.chunk(2)
+                |> Enum.chunk_every(2, 2, :discard)
                 |> Enum.join(":")
               )
 
@@ -456,7 +456,7 @@ defmodule EasySSL do
                     authority_key_identifier
                     |> Base.encode16
                     |> String.to_charlist
-                    |> Enum.chunk(2)
+                    |> Enum.chunk_every(2, 2, :discard)
                     |> Enum.join(":")
                     |> String.replace_prefix("", "keyid:")
                     |> String.replace_suffix("", "\n")


### PR DESCRIPTION
I bumped into following warning when executing tests.
```sh
$ mix test
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
  mix.exs:13

Compiling 1 file (.ex)
warning: Enum.chunk/2 is deprecated. Use Enum.chunk_every/2 instead
Found at 3 locations:
  lib/easy_ssl.ex:175
  lib/easy_ssl.ex:302
  lib/easy_ssl.ex:459

....

Finished in 0.2 seconds
4 tests, 0 failures
```
So I replaced `Enum.chunk/2` with `Enum.chunk_every/2`.
(ref. https://hexdocs.pm/elixir/Enum.html#chunk_every/4)