### PR TITLE
Incorrect timestamp returned by `to_generalized_time`

### DIFF
--- a/lib/easy_ssl.ex
+++ b/lib/easy_ssl.ex
@@ -190,7 +190,7 @@ defmodule EasySSL do
 
   defp to_generalized_time({:generalTime, time}), do: time
   defp to_generalized_time({:utcTime, time}) do
-    year = time |> Enum.take(2) |> :string.to_integer()
+    year = time |> Enum.take(2) |> List.to_integer()
     prefix = if year >=  50, do: '19', else: '20'
     prefix ++ time
   end

--- a/test/easy_ssl_test.exs
+++ b/test/easy_ssl_test.exs
@@ -87,4 +87,18 @@ defmodule EasySSLTest do
     assert cert.not_after == :no_expiration
   end
 
+  test "parses validity dates correctly" do
+    cert = File.read!(@pem_cert_dir <> "github.com.crt") |> EasySSL.parse_pem()
+    assert Map.has_key?(cert, :not_before)
+    assert Map.has_key?(cert, :not_after)
+
+    {:ok, correct_before, _offset} = DateTime.from_iso8601("2013-06-10T00:00:00Z")
+    {:ok, correct_after, _offset} = DateTime.from_iso8601("2015-09-02T12:00:00Z")
+    {:ok, actual_before} = DateTime.from_unix(cert.not_before)
+    {:ok, actual_after} = DateTime.from_unix(cert.not_after)
+
+    assert actual_before == correct_before
+    assert actual_after == correct_after
+  end
+
 end


### PR DESCRIPTION
Result of `year = time |> Enum.take(2)` is a charlist, not a string, as `year` is a charlist.