### PR TITLE
Cert signature algorithm parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ We aim to make the usage as stupid simple as possible, so there are only 2 expor
   not_after: 1398523877,
   not_before: 1366987877,
   serial_number: "27ACAE30B9F323",
+  signature_algorithm: "sha, rsa",
   subject: %{
     C: nil,
     CN: "www.acaline.com",

--- a/lib/easy_ssl.ex
+++ b/lib/easy_ssl.ex
@@ -49,6 +49,7 @@ defmodule EasySSL do
         not_after: 1398523877,
         not_before: 1366987877,
         serial_number: "27ACAE30B9F323",
+        signature_algorithm: "sha, rsa",
         subject: %{
           C: nil,
           CN: "www.acaline.com",
@@ -66,6 +67,7 @@ defmodule EasySSL do
     serialized_certificate = %{}
       |> Map.put(:fingerprint, certificate_der |> fingerprint_cert)
       |> Map.put(:serial_number, cert |> get_field(:serialNumber) |> Integer.to_string(16))
+      |> Map.put(:signature_algorithm, cert |> parse_signature_algo)
       |> Map.put(:subject, cert |> parse_subject)
       |> Map.put(:extensions, cert |> parse_extensions)
       |> Map.merge(parse_expiry(cert))
@@ -214,6 +216,16 @@ defmodule EasySSL do
         Logger.error("Unhandled ASN1 time structure - #{date_args}}")
         nil
     end
+  end
+
+  defp parse_signature_algo(cert) do
+    cert
+    |> get_field(:signature)
+    |> get_field(:algorithm)
+    |> :public_key.pkix_sign_types()
+    |> Tuple.to_list()
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.join(", ")
   end
 
   defp parse_subject(cert) do

--- a/test/easy_ssl_test.exs
+++ b/test/easy_ssl_test.exs
@@ -5,14 +5,14 @@ defmodule EasySSLTest do
   @pem_cert_dir "test/data/pem/"
 
   def assert_has_normal_atom_keys(cert) do
-    keys = [:extensions, :fingerprint, :not_after, :not_before, :serial_number, :subject]
+    keys = [:extensions, :fingerprint, :not_after, :not_before, :serial_number, :signature_algorithm, :subject]
     Enum.each(keys, fn key ->
       assert Map.has_key?(cert, key)
     end)
   end
 
   def assert_has_normal_string_keys(cert) do
-    keys = ["extensions", "fingerprint", "not_after", "not_before", "serial_number", "subject"]
+    keys = ["extensions", "fingerprint", "not_after", "not_before", "serial_number", "signature_algorithm", "subject"]
     Enum.each(keys, fn key ->
       assert Map.has_key?(cert, key)
     end)


### PR DESCRIPTION
👋 

**Use case**:
I'm having a case now where I need to know if the certificate is using SHA1 as signature algorithm. SHA1 is deprecated in TLS 1.2 ([*](https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html)) and most browsers block certs signed with SHA1 ([*](https://sha1-intermediate.badssl.com)). However Erlang's `:ssl` module does not validate signature algorithm. 

**Fix**:
Added a field for `signature_algorithm` that returns the stringified version of `:public_key.pkix_sign_types()` for the cert.

Thank you for your review and consideration.