### PR TITLE
Add sha256 fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ We aim to make the usage as stupid simple as possible, so there are only 2 expor
     subjectKeyIdentifier: "E6:61:14:4E:5A:4B:51:0C:4E:6C:5E:3C:79:61:65:D4:BD:64:94:BE"
   },
   fingerprint: "FA:BE:B5:9B:ED:C2:2B:42:7E:B1:45:C8:9A:8A:73:16:4A:A0:10:09",
+  fingerprint_sha256: "FA:BE:B5:9B:ED:C2:2B:42:7E:B1:45:C8:9A:8A:73:16:4A:A0:10:09:C1:1A:C0:DE:D7:65:58:07:10:3E:1B:59:1E:A6:E9:7B:47",
   issuer: %{
     C: "US",
     CN: "Go Daddy Secure Certification Authority",
@@ -74,6 +75,7 @@ iex(1)> File.read!("some_cert.der") |> EasySSL.parse_der
     ...SNIP...
   },
   fingerprint: "FA:BE:B5:9B:ED:C2:2B:42:7E:B1:45:C8:9A:8A:73:16:4A:A0:10:09",
+  fingerprint_sha256: "...",
   issuer: %{
     ...SNIP...
   },
@@ -99,6 +101,7 @@ iex(1)> File.read!("some_cert.pem") |> EasySSL.parse_pem
     ...SNIP...
   },
   fingerprint: "FA:BE:B5:9B:ED:C2:2B:42:7E:B1:45:C8:9A:8A:73:16:4A:A0:10:09",
+  fingerprint: "....",
   issuer: %{
     ...SNIP...
   },

--- a/lib/easy_ssl.ex
+++ b/lib/easy_ssl.ex
@@ -46,6 +46,7 @@ defmodule EasySSL do
           subjectKeyIdentifier: "E6:61:14:4E:5A:4B:51:0C:4E:6C:5E:3C:79:61:65:D4:BD:64:94:BE"
         },
         fingerprint: "FA:BE:B5:9B:ED:C2:2B:42:7E:B1:45:C8:9A:8A:73:16:4A:A0:10:09",
+        fingerprint_sha256: "FA:BE:B5:9B:ED:C2:2B:42:7E:B1:45:C8:9A:8A:73:16:4A:A0:10:09:DE:AD:BE:EF:CA:FE:BA:BE",
         issuer: %{
           C: "US",
           CN: "Go Daddy Secure Certification Authority",
@@ -76,7 +77,8 @@ defmodule EasySSL do
     cert = :public_key.pkix_decode_cert(certificate_der, :otp) |> get_field(:tbsCertificate)
 
     serialized_certificate = %{}
-      |> Map.put(:fingerprint, certificate_der |> fingerprint_cert)
+      |> Map.put(:fingerprint, certificate_der |> fingerprint_cert(:sha))
+      |> Map.put(:fingerprint_sha256, certificate_der |> fingerprint_cert(:sha256))
       |> Map.put(:serial_number, cert |> get_field(:serialNumber) |> Integer.to_string(16))
       |> Map.put(:signature_algorithm, cert |> parse_signature_algo)
       |> Map.put(:subject, cert |> parse_rdnsequence(:subject))
@@ -197,8 +199,8 @@ defmodule EasySSL do
     elem(record, idx + 1)
   end
 
-  defp fingerprint_cert(certificate) do
-    :crypto.hash(:sha, certificate)
+  defp fingerprint_cert(certificate, algorithm) do
+    :crypto.hash(algorithm, certificate)
     |> Base.encode16
     |> String.to_charlist
     |> Enum.chunk_every(2, 2, :discard)

--- a/test/easy_ssl_test.exs
+++ b/test/easy_ssl_test.exs
@@ -5,14 +5,14 @@ defmodule EasySSLTest do
   @pem_cert_dir "test/data/pem/"
 
   def assert_has_normal_atom_keys(cert) do
-    keys = [:extensions, :fingerprint, :issuer, :not_after, :not_before, :serial_number, :signature_algorithm, :subject]
+    keys = [:extensions, :fingerprint, :fingerprint_sha256, :issuer, :not_after, :not_before, :serial_number, :signature_algorithm, :subject]
     Enum.each(keys, fn key ->
       assert Map.has_key?(cert, key)
     end)
   end
 
   def assert_has_normal_string_keys(cert) do
-    keys = ["extensions", "fingerprint", "issuer", "not_after", "not_before", "serial_number", "signature_algorithm", "subject"]
+    keys = ["extensions", "fingerprint", "fingerprint_sha256", "issuer", "not_after", "not_before", "serial_number", "signature_algorithm", "subject"]
     Enum.each(keys, fn key ->
       assert Map.has_key?(cert, key)
     end)


### PR DESCRIPTION
SHA256 seems to be somewhat of a standard for certificate fingerprints. For example from google chrome:

![2022-12-15-141335_510x587_scrot](https://user-images.githubusercontent.com/63001662/207868086-d2b4ae7b-77d0-4be6-b938-e1be1e8531ee.png)
