### PR TITLE
Make it compile on Elixir 1.15

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule EasySSL.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :private_key]
     ]
   end
 


### PR DESCRIPTION
Since Elixir 1.15 introduces code path pruning this library cannot compile anymore without the `:private_key` application in `extra_application`.