### PR TITLE
Fix recent OTP issues

### DIFF
--- a/lib/easy_ssl.ex
+++ b/lib/easy_ssl.ex
@@ -313,6 +313,14 @@ defmodule EasySSL do
 
   end
 
+  defp parse_crl_distribution_points(crl_distribution_points)
+       when is_binary(crl_distribution_points) do
+    :public_key.der_decode(:CRLDistributionPoints, crl_distribution_points)
+  end
+  defp parse_crl_distribution_points(crl_distribution_points) do
+    crl_distribution_points
+  end
+
   defp coerce_to_string(attribute_value) do
     case attribute_value do
       {:printableString, string} -> string
@@ -456,6 +464,7 @@ defmodule EasySSL do
                 extension_map,
                 :crlDistributionPoints,
                 crl_distribution_points
+                |> parse_crl_distribution_points
                 |> Enum.reduce([], fn distro_point, output ->
                   case distro_point do
                     {:DistributionPoint, {:fullName, crls}, :asn1_NOVALUE, :asn1_NOVALUE} ->

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule EasySSL.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :public_key]
     ]
   end
 


### PR DESCRIPTION
This PR fixes recent OTP related issues. 

- Add `public_key` extra application to work along with OTP 26+ (#17)
- Fix `Protocol.UndefinedError` in recent OTP (#16 / thanks to @andrewtimberlake for his advice)
  - I'm not sure which OTP version introduces this change but at least OTP 24+ needs this patch.